### PR TITLE
README.rst: Fix python-cryptography link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,8 @@ Building the module
 
 SecretStorage requires these packages to work:
 
-* `dbus-python`_;
-* `python-cryptography_`.
+* `dbus-python`_
+* `python-cryptography`_
 
 To build SecretStorage, use this command::
 


### PR DESCRIPTION
The underscore was in the wrong place.

https://github.com/msabramo/secretstorage/blob/patch-1/README.rst