### PR TITLE
Support cryptography 2.5's use of ffi.from_buffer()

### DIFF
--- a/secretstorage/item.py
+++ b/secretstorage/item.py
@@ -103,7 +103,7 @@ class Item(object):
 		aes_iv = bytes(secret[1])
 		decryptor = Cipher(aes, modes.CBC(aes_iv), default_backend()).decryptor()
 		encrypted_secret = secret[2]
-		padded_secret = decryptor.update(encrypted_secret) + decryptor.finalize()
+		padded_secret = decryptor.update(bytearray(encrypted_secret)) + decryptor.finalize()
 		assert isinstance(padded_secret, bytes)
 		return padded_secret[:-padded_secret[-1]]
 

--- a/secretstorage/item.py
+++ b/secretstorage/item.py
@@ -103,7 +103,7 @@ class Item(object):
 		aes_iv = bytes(secret[1])
 		decryptor = Cipher(aes, modes.CBC(aes_iv), default_backend()).decryptor()
 		encrypted_secret = secret[2]
-		padded_secret = decryptor.update(bytearray(encrypted_secret)) + decryptor.finalize()
+		padded_secret = decryptor.update(bytes(encrypted_secret)) + decryptor.finalize()
 		assert isinstance(padded_secret, bytes)
 		return padded_secret[:-padded_secret[-1]]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,4 @@ platforms = Linux
 [options]
 packages = secretstorage
 python_requires = >=3.5
-install_requires = cryptography; jeepney
+install_requires = cryptography >=2.5; jeepney

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,4 @@ platforms = Linux
 [options]
 packages = secretstorage
 python_requires = >=3.5
-install_requires = cryptography >=2.5; jeepney
+install_requires = cryptography; jeepney


### PR DESCRIPTION
Fixes #16
Note that this change is only compatible with `cryptography` >= 2.5.