### PR TITLE
Use new-style Jeepney blocking I/O API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: focal
 language: python
 matrix:
   include:
-    - python: "3.5"
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"

--- a/secretstorage/__init__.py
+++ b/secretstorage/__init__.py
@@ -8,8 +8,7 @@ refer to documentation of individual modules for API details.
 """
 
 from jeepney.bus_messages import message_bus
-from jeepney.integrate.blocking import DBusConnection, Proxy, \
- connect_and_authenticate
+from jeepney.io.blocking import DBusConnection, Proxy, open_dbus_connection
 
 from secretstorage.collection import Collection, create_collection, \
  get_all_collections, get_default_collection, get_any_collection, \
@@ -70,7 +69,7 @@ def dbus_init() -> DBusConnection:
 	   This function no longer accepts any arguments.
 	"""
 	try:
-		connection = connect_and_authenticate()
+		connection = open_dbus_connection()
 		add_match_rules(connection)
 		return connection
 	except KeyError as ex:

--- a/secretstorage/collection.py
+++ b/secretstorage/collection.py
@@ -16,7 +16,7 @@ asynchronous). Creating new items and editing existing ones is possible
 only in unlocked collection."""
 
 from typing import Dict, Iterator, Optional
-from jeepney.integrate.blocking import DBusConnection
+from jeepney.io.blocking import DBusConnection
 from secretstorage.defines import SS_PREFIX, SS_PATH
 from secretstorage.dhcrypto import Session
 from secretstorage.exceptions import LockedException, ItemNotFoundException, \

--- a/secretstorage/item.py
+++ b/secretstorage/item.py
@@ -10,7 +10,7 @@ the item is unlocked. The collection can be unlocked using collection's
 :meth:`~secretstorage.collection.Collection.unlock` method."""
 
 from typing import Dict, Optional
-from jeepney.integrate.blocking import DBusConnection
+from jeepney.io.blocking import DBusConnection
 from secretstorage.defines import SS_PREFIX
 from secretstorage.dhcrypto import Session
 from secretstorage.exceptions import LockedException, PromptDismissedException

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -25,5 +24,5 @@ platforms = Linux
 
 [options]
 packages = secretstorage
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires = cryptography>=2.0; jeepney>=0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,4 @@ platforms = Linux
 [options]
 packages = secretstorage
 python_requires = >=3.5
-install_requires = cryptography>=2.0; jeepney>=0.4.2
+install_requires = cryptography>=2.0; jeepney>=0.5


### PR DESCRIPTION
No rush to merge this - I've preserved the existing APIs for now - but I wanted to illustrate what the changes are to use Jeepney's new I/O integration more or less canonically. At some point the old APIs will go away.

This is also the release that will allow you to impose a timeout on method calls if you want.