### PR TITLE
Update deprecated int_from_bytes to int.from_bytes

### DIFF
--- a/secretstorage/dhcrypto.py
+++ b/secretstorage/dhcrypto.py
@@ -13,7 +13,6 @@ import os
 
 from hashlib import sha256
 from typing import Optional  # Needed for mypy
-from cryptography.utils import int_from_bytes
 
 # A standard 1024 bits (128 bytes) prime number for use in Diffie-Hellman exchange
 DH_PRIME_1024_BYTES = (
@@ -30,7 +29,7 @@ DH_PRIME_1024_BYTES = (
 def int_to_bytes(number: int) -> bytes:
 	return number.to_bytes(math.ceil(number.bit_length() / 8), 'big')
 
-DH_PRIME_1024 = int_from_bytes(DH_PRIME_1024_BYTES, 'big')
+DH_PRIME_1024 = int.from_bytes(DH_PRIME_1024_BYTES, 'big')
 
 class Session(object):
 	def __init__(self) -> None:
@@ -38,7 +37,7 @@ class Session(object):
 		self.aes_key = None  # type: Optional[bytes]
 		self.encrypted = True
 		# 128-bytes-long strong random number
-		self.my_private_key = int_from_bytes(os.urandom(0x80), 'big')
+		self.my_private_key = int.from_bytes(os.urandom(0x80), 'big')
 		self.my_public_key = pow(2, self.my_private_key, DH_PRIME_1024)
 
 	def set_server_public_key(self, server_public_key: int) -> None:

--- a/secretstorage/dhcrypto.py
+++ b/secretstorage/dhcrypto.py
@@ -41,9 +41,9 @@ class Session(object):
 		self.my_public_key = pow(2, self.my_private_key, DH_PRIME_1024)
 
 	def set_server_public_key(self, server_public_key: int) -> None:
-		common_secret = pow(server_public_key, self.my_private_key,
+		common_secret_int = pow(server_public_key, self.my_private_key,
 			DH_PRIME_1024)
-		common_secret = int_to_bytes(common_secret)
+		common_secret = int_to_bytes(common_secret_int)
 		# Prepend NULL bytes if needed
 		common_secret = b'\x00' * (0x80 - len(common_secret)) + common_secret
 		# HKDF with null salt, empty info and SHA-256 hash

--- a/secretstorage/util.py
+++ b/secretstorage/util.py
@@ -22,7 +22,6 @@ from secretstorage.exceptions import ItemNotFoundException, \
  SecretServiceNotAvailableException
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
-from cryptography.utils import int_from_bytes
 
 BUS_NAME = 'org.freedesktop.secrets'
 SERVICE_IFACE = SS_PREFIX + 'Service'
@@ -88,7 +87,7 @@ def open_session(connection: DBusConnection) -> Session:
 	else:
 		signature, value = output
 		assert signature == 'ay'
-		key = int_from_bytes(value, 'big')
+		key = int.from_bytes(value, 'big')
 		session.set_server_public_key(key)
 	session.object_path = result
 	return session


### PR DESCRIPTION
[Cryptography 3.4](https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst) is now released.
It drops Python 2 support: https://github.com/pyca/cryptography/pull/5533
and deprecates usage of `utils.int_from_bytes`: https://github.com/pyca/cryptography/pull/5609

`int_from_bytes` is deprecated in favor of `int.from_bytes` which ships with Python 3:
```
/usr/local/lib/python3.8/dist-packages/secretstorage/dhcrypto.py:16: CryptographyDeprecationWarning: int_from_bytes is deprecated, use int.from_bytes instead
  from cryptography.utils import int_from_bytes
/usr/local/lib/python3.8/dist-packages/secretstorage/util.py:25: CryptographyDeprecationWarning: int_from_bytes is deprecated, use int.from_bytes instead
  from cryptography.utils import int_from_bytes
```

Changing all references to `int_from_bytes` to `int.from_bytes` as suggested in the deprecation warnings and removing obsolete imports.

Fixes #28.