### PR TITLE
Handle DBus UnknownObject error when no collection is found

### DIFF
--- a/secretstorage/defines.py
+++ b/secretstorage/defines.py
@@ -15,6 +15,7 @@ DBUS_EXEC_FAILED = 'org.freedesktop.DBus.Error.Spawn.ExecFailed'
 DBUS_NO_REPLY = 'org.freedesktop.DBus.Error.NoReply'
 DBUS_NOT_SUPPORTED = 'org.freedesktop.DBus.Error.NotSupported'
 DBUS_NO_SUCH_OBJECT = 'org.freedesktop.Secret.Error.NoSuchObject'
+DBUS_UNKNOWN_OBJECT = 'org.freedesktop.DBus.Error.UnknownObject'
 
 ALGORITHM_PLAIN = 'plain'
 ALGORITHM_DH = 'dh-ietf1024-sha256-aes128-cbc-pkcs7'

--- a/secretstorage/util.py
+++ b/secretstorage/util.py
@@ -16,7 +16,7 @@ from jeepney import (
 from jeepney.io.blocking import DBusConnection
 from secretstorage.defines import DBUS_UNKNOWN_METHOD, DBUS_NO_SUCH_OBJECT, \
  DBUS_SERVICE_UNKNOWN, DBUS_NO_REPLY, DBUS_NOT_SUPPORTED, DBUS_EXEC_FAILED, \
- SS_PATH, SS_PREFIX, ALGORITHM_DH, ALGORITHM_PLAIN
+ DBUS_UNKNOWN_OBJECT, SS_PATH, SS_PREFIX, ALGORITHM_DH, ALGORITHM_PLAIN
 from secretstorage.dhcrypto import Session, int_to_bytes
 from secretstorage.exceptions import ItemNotFoundException, \
  SecretServiceNotAvailableException
@@ -48,7 +48,7 @@ class DBusAddressWrapper(DBusAddress):  # type: ignore
                 raise DBusErrorResponse(resp_msg)
             return resp_msg.body
         except DBusErrorResponse as resp:
-            if resp.name in (DBUS_UNKNOWN_METHOD, DBUS_NO_SUCH_OBJECT):
+            if resp.name in (DBUS_UNKNOWN_METHOD, DBUS_NO_SUCH_OBJECT, DBUS_UNKNOWN_OBJECT):
                 raise ItemNotFoundException('Item does not exist!') from resp
             elif resp.name in (DBUS_SERVICE_UNKNOWN, DBUS_EXEC_FAILED,
                                DBUS_NO_REPLY):

--- a/secretstorage/util.py
+++ b/secretstorage/util.py
@@ -48,7 +48,11 @@ class DBusAddressWrapper(DBusAddress):  # type: ignore
                 raise DBusErrorResponse(resp_msg)
             return resp_msg.body
         except DBusErrorResponse as resp:
-            if resp.name in (DBUS_UNKNOWN_METHOD, DBUS_NO_SUCH_OBJECT, DBUS_UNKNOWN_OBJECT):
+            if resp.name in (
+                DBUS_UNKNOWN_METHOD,
+                DBUS_NO_SUCH_OBJECT,
+                DBUS_UNKNOWN_OBJECT,
+            ):
                 raise ItemNotFoundException('Item does not exist!') from resp
             elif resp.name in (DBUS_SERVICE_UNKNOWN, DBUS_EXEC_FAILED,
                                DBUS_NO_REPLY):


### PR DESCRIPTION
On Kubuntu 23.04, when trying to access a collection that doesn't exist, it returns a UnknownObject error instead of NoSuchObject. Which makes me unable of installing the package on the system.

Handling this case, makes the KWallet dialog for creating the wallet appears and the rest of workflow works as expected.