### PR TITLE
pass code over `pyupgrade --py39`

### DIFF
--- a/secretstorage/__init__.py
+++ b/secretstorage/__init__.py
@@ -75,7 +75,7 @@ def dbus_init() -> DBusConnection:
         return connection
     except KeyError as ex:
         # os.environ['DBUS_SESSION_BUS_ADDRESS'] may raise it
-        reason = "Environment variable {} is unset".format(ex.args[0])
+        reason = f"Environment variable {ex.args[0]} is unset"
         raise SecretServiceNotAvailableException(reason) from ex
     except (ConnectionError, ValueError) as ex:
         raise SecretServiceNotAvailableException(str(ex)) from ex

--- a/secretstorage/collection.py
+++ b/secretstorage/collection.py
@@ -16,7 +16,8 @@ Creating new items and editing existing ones is possible only in unlocked
 collections.
 """
 
-from typing import Iterator, Optional
+from typing import Optional
+from collections.abc import Iterator
 from jeepney.io.blocking import DBusConnection
 from secretstorage.defines import SS_PREFIX, SS_PATH
 from secretstorage.dhcrypto import Session

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -74,7 +74,7 @@ class ItemTest(unittest.TestCase):
         # string passwords are encoded as bytes
         self.item.set_secret('test тест')  # type: ignore
         self.assertEqual(self.item.get_secret(),
-                         'test тест'.encode('utf-8'))
+                         'test тест'.encode())
         # other types are not allowed
         with self.assertRaises(TypeError):
             self.item.set_secret(None)  # type: ignore


### PR DESCRIPTION
Currently minimum python version is 3..9.
Pass code over `pyupgrade --py39`.